### PR TITLE
Add heredoc indentation fixer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1",
-        "symplify/easy-coding-standard": "^8.2"
+        "symplify/easy-coding-standard": "^9.2"
     },
     "require-dev": {
     },

--- a/ecs.php
+++ b/ecs.php
@@ -35,6 +35,7 @@ use PhpCsFixer\Fixer\ReturnNotation\ReturnAssignmentFixer;
 use PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer;
 use PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
+use PhpCsFixer\Fixer\Whitespace\HeredocIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoTrailingWhitespaceFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
@@ -146,4 +147,6 @@ return static function (ContainerConfigurator $config) use ($psr12, $cleanCode, 
             ],
         ],
     ]);
+
+    $services->set(HeredocIndentationFixer::class)->call('configure', [['indentation' => 'same_as_start']]);
 };


### PR DESCRIPTION
Had to up `php-cs-fixer` to `>=2.17` (and in turn, `easy-coding-standard` to `>=9.0, <=9.4`) to have the configuration option for this fixer.

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/whitespace/heredoc_indentation.rst