### PR TITLE
chore/make some libs to be peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8",
-                "eslint-config-next": "^13 || ^14",
+                "eslint-config-next": "^13 || ^14 || 15 || rc",
                 "eslint-plugin-react": "^7.36.0",
                 "eslint-plugin-react-hooks": "^4.5.0",
                 "prettier": "^2 || ^3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
             "peerDependencies": {
                 "eslint": "^8",
                 "eslint-config-next": "^13 || ^14",
+                "eslint-plugin-react": "^7.36.0",
+                "eslint-plugin-react-hooks": "^4.5.0",
                 "prettier": "^2 || ^3",
                 "stylelint": "^16.2.0"
             },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     },
     "peerDependencies": {
         "eslint": "^8",
-        "eslint-config-next": "^13 || ^14",
+        "eslint-config-next": "^13 || ^14 || 15 || rc",
         "prettier": "^2 || ^3",
         "stylelint": "^16.2.0",
         "eslint-plugin-react": "^7.36.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
         "eslint": "^8",
         "eslint-config-next": "^13 || ^14",
         "prettier": "^2 || ^3",
-        "stylelint": "^16.2.0"
+        "stylelint": "^16.2.0",
+        "eslint-plugin-react": "^7.36.0",
+        "eslint-plugin-react-hooks": "^4.5.0"
     },
     "peerDependenciesMeta": {
         "eslint-config-next": {


### PR DESCRIPTION
- **Make `eslint-plugin-react` and `eslint-plugin-react-hooks` to be peer deps**
- **Update `eslint-config-next` peer dependency version**
